### PR TITLE
Feat: Update Regattas Summary

### DIFF
--- a/packages/core/src/entities/regatta.ts
+++ b/packages/core/src/entities/regatta.ts
@@ -30,6 +30,14 @@ export const Regatta = new Entity({
       required: true,
       type: "string",
     },
+    participantDescription: {
+      required: true,
+      type: "string",
+    },
+    rampClosed: {
+      required: true,
+      type: "boolean",
+    },
     distance: {
       required: true,
       type: "number",

--- a/packages/functions/src/databaseSeed.ts
+++ b/packages/functions/src/databaseSeed.ts
@@ -49,9 +49,11 @@ async function createRandomRegatta() {
 
   const regatta = await RegattaService.entities.regatta
     .put({
-      name: "Test Regatta " + crypto.randomUUID(), // Generate a type
+      name: "Test Regatta", // Generate a type
       type: regattaType, // Randomly pick a type
       host: host,
+      participantDescription: "New England Teams",
+      rampClosed: regattaType !== "duel",
       distance: [2000, 5000][crypto.randomInt(0, 2)], // Pick either 2k or 5k cuz why not
       startDate: date,
       endDate: date + dayInMilliseconds * [0, 1][crypto.randomInt(0, 2)], // Regatta either ends same day or one day later

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -23,6 +23,11 @@ export default {
     };
   },
   stacks(app) {
+    // Remove all resources (e.g., including DynamoDB/S3 Buckets) in non-prod instances
+    if (app.stage !== "prod") {
+      app.setDefaultRemovalPolicy("destroy");
+    }
+
     app.stack(SiteStack).stack(CICDStack);
   },
 } satisfies SSTConfig;


### PR DESCRIPTION
Updated the regattas summary data to include participants (as a string) and ramp closure status (as a boolean).

This resolves "Lake Schedule DB Updates"

This also **fixes a bug where DynamoDB and S3 Resources are not cleaned up in dev**