### PR TITLE
Feat: Update Regatta DB Info

### DIFF
--- a/packages/core/src/entities/break.ts
+++ b/packages/core/src/entities/break.ts
@@ -1,0 +1,54 @@
+import { Entity } from "electrodb";
+import { ulid } from "ulid";
+import { databaseConfiguration } from "../dynamo.ts";
+
+export const Break = new Entity({
+  model: {
+    entity: "break",
+    version: "1",
+    service: "regattas",
+  },
+  attributes: {
+    // ID of the regatta this break belongs to
+    regattaId: {
+      required: true,
+      type: "string",
+      readOnly: true,
+    },
+    breakId: {
+      required: true,
+      type: "string",
+      readOnly: true,
+      default: () => ulid(),
+    },
+    // Epoch MS
+    scheduledStart: {
+      type: "number",
+      required: true,
+    },
+    // Delay in MS
+    delay: {
+      type: "number",
+      required: false,
+    },
+    status: {
+      required: true,
+      type: ["scheduled", "delayed", "complete", "in-progress"] as const,
+    },
+  },
+  indexes: {
+    // Enables querying everything about a regatta (e.g., summary info and heats)
+    regatta: {
+      collection: "regatta",
+      pk: {
+        field: "pk",
+        composite: ["regattaId"],
+      },
+      sk: {
+        field: "sk",
+        composite: ["breakId"],
+      },
+    },
+  },
+  databaseConfiguration,
+});

--- a/packages/core/src/entities/heat.ts
+++ b/packages/core/src/entities/heat.ts
@@ -93,10 +93,37 @@ export const Heat = new Entity({
             required: true,
             type: "number",
           },
-          // Finish time in MS
+          // Finish time in MS. RAW IF THERE IS A PENALTY
           finishTime: {
             required: false,
             type: "number",
+          },
+          // Should be set to true if a crew fails to finish
+          didFailToFinish: {
+            required: false,
+            type: "boolean",
+          },
+          // Details about a potential penalty
+          penalty: {
+            required: false,
+            type: "map",
+            properties: {
+              // Type of the penalty
+              type: {
+                required: true,
+                type: ["dsq", "time", "warning"] as const,
+              },
+              // Reason for the penalty
+              reason: {
+                required: true,
+                type: "string",
+              },
+              // The time (added to finish time) for the penalty
+              time: {
+                required: false,
+                type: "string",
+              },
+            },
           },
           segments: {
             // Optional (because this isn't always collected) distance/time pairs at intermediate points in the race

--- a/packages/core/src/entities/heat.ts
+++ b/packages/core/src/entities/heat.ts
@@ -56,7 +56,13 @@ export const Heat = new Entity({
     },
     status: {
       required: true,
-      type: ["scheduled", "delayed", "unofficial", "official"] as const,
+      type: [
+        "scheduled",
+        "delayed",
+        "unofficial",
+        "official",
+        "in-progress",
+      ] as const,
     },
     // Progression information, optional. Should contain the number to the next heat, and the ID of the next heat
     progression: {

--- a/packages/core/src/entities/heat.ts
+++ b/packages/core/src/entities/heat.ts
@@ -127,7 +127,7 @@ export const Heat = new Entity({
               // The time (added to finish time) for the penalty
               time: {
                 required: false,
-                type: "string",
+                type: "number",
               },
             },
           },

--- a/packages/core/src/entities/heat.ts
+++ b/packages/core/src/entities/heat.ts
@@ -37,9 +37,7 @@ export const Heat = new Entity({
           type: ["men", "women", "open"] as const,
         },
         displayName: {
-          // Since a heat may contain some type information that can't be represented by only class and gender,
-          // this enables that (this can be masters, 2v, etc.)
-          required: false,
+          required: true,
           type: "string",
         },
       },

--- a/packages/core/src/services.ts
+++ b/packages/core/src/services.ts
@@ -1,5 +1,6 @@
 import { Service } from "electrodb";
 import { databaseConfiguration } from "./dynamo.ts";
+import { Break } from "./entities/break.ts";
 import { Heat } from "./entities/heat.ts";
 import { Regatta } from "./entities/regatta.ts";
 import { Team } from "./entities/team.ts";
@@ -21,6 +22,7 @@ export const RegattaService = new Service(
   {
     regatta: Regatta,
     heat: Heat,
+    break: Break,
   },
   databaseConfiguration,
 );

--- a/packages/functions/src/databaseSeed.ts
+++ b/packages/functions/src/databaseSeed.ts
@@ -56,7 +56,7 @@ async function createRandomRegatta() {
       rampClosed: regattaType !== "duel",
       distance: [2000, 5000][crypto.randomInt(0, 2)], // Pick either 2k or 5k cuz why not
       startDate: date,
-      endDate: date + dayInMilliseconds * [0, 1][crypto.randomInt(0, 2)], // Regatta either ends same day or one day later
+      endDate: date + dayInMilliseconds * [1, 2][crypto.randomInt(0, 2)], // Regatta either ends same day or one day later
     })
     .go();
 

--- a/packages/functions/src/databaseSeed.ts
+++ b/packages/functions/src/databaseSeed.ts
@@ -142,10 +142,7 @@ function createRandomHeatCreateArgs(
     boatClass,
     gender,
     // Decide whether to create a manual display name randomly
-    displayName:
-      crypto.randomInt(0, 2) === 1
-        ? `${gender}'s ${crypto.randomInt(1, 5)} Varsity ${boatClass}`
-        : undefined,
+    displayName: `${gender}'s ${crypto.randomInt(1, 5)} Varsity ${boatClass}`,
   };
 
   // Return the parsed heat information

--- a/packages/site/src/lib/utils/regattas/converters.ts
+++ b/packages/site/src/lib/utils/regattas/converters.ts
@@ -10,9 +10,119 @@ import { CollectionItem, EntityItem } from "electrodb";
 export function convertDbHeatToHeat(
   heat: EntityItem<typeof RegattaService.entities.heat>,
 ) {
+  // For each entry, add in computed finish time and rename finish time to raw finish time
+  const entriesNoDelta = heat.entries.map((entry) => {
+    // Compute the final finish time
+    let finalFinishTime: number | undefined;
+
+    // If we have a finish time
+    if (entry.finishTime) {
+      // If we have a non-warning penalty
+      if (entry.penalty && entry.penalty.type !== "warning") {
+        // If it's a time penalty, apply it
+        if (entry.penalty.type === "time") {
+          // Compute the final finish time based on the raw + penalty
+          finalFinishTime =
+            entry.finishTime + (entry.penalty.time ? entry.penalty.time : 0);
+        }
+
+        // If it's a DSQ, just let it be undefined
+      } else {
+        // If we don't have a penalty, just use the raw
+        finalFinishTime = entry.finishTime;
+      }
+    }
+
+    // Now remove the original finish time attribute and keep only raw and final
+    const result: Omit<typeof entry, "finishTime"> & {
+      rawFinishTime?: number;
+      finalFinishTime?: number;
+    } = {
+      ...entry,
+      rawFinishTime: entry.finishTime,
+      finalFinishTime: finalFinishTime,
+    };
+
+    // Don't use inline so we get better typing on this
+    return result;
+  });
+
+  // Order in the following way
+  // Start with entries with final finish time (ordered by that)
+  // then, DNFs (ordered by bow number)
+  // Then, DSQs (ordered by raw finish order)
+  // Then, fall back to bow number order
+  const entriesSorted = entriesNoDelta.toSorted((a, b) => {
+    if (a.finalFinishTime && b.finalFinishTime) {
+      return b.finalFinishTime - a.finalFinishTime; // Reverse cuz lower is higher in this case
+    } else if (a.finalFinishTime) {
+      return 1;
+    } else if (b.finalFinishTime) {
+      return -1;
+    } else if (a.didFailToFinish && b.didFailToFinish) {
+      return a.bowNumber - b.bowNumber;
+    } else if (a.didFailToFinish) {
+      return 1;
+    } else if (b.didFailToFinish) {
+      return -1;
+    } else if (a.penalty && b.penalty && a.rawFinishTime && b.rawFinishTime) {
+      return b.rawFinishTime - a.rawFinishTime; // Again, reverse cuz lower is higher
+    } else if (a.penalty) {
+      return 1;
+    } else if (b.penalty) {
+      return -1;
+    } else {
+      return a.bowNumber - b.bowNumber;
+    }
+  });
+
+  // Types that the final entries should be
+  type BaseEntry = (typeof entriesNoDelta)[0];
+  type EntryWithDeltas = BaseEntry & {
+    deltaToWinner: number | undefined;
+    deltaToNext: number | undefined;
+  };
+
+  const entriesWithDelta: EntryWithDeltas[] = [];
+
+  // Iterate through the entries
+  for (let i = 0; i < entriesSorted.length; i++) {
+    // If we don't have a final finish time for this crew, just put them in without one
+    if (entriesSorted[i].finalFinishTime === undefined) {
+      entriesWithDelta.push({
+        ...entriesSorted[i],
+        deltaToNext: undefined,
+        deltaToWinner: undefined,
+      });
+      continue; // Don't process more
+    }
+
+    if (i === 0) {
+      // If this is the first, delta to next/winner is 0
+      entriesWithDelta.push({
+        ...entriesSorted[i],
+        deltaToNext: 0,
+        deltaToWinner: 0,
+      });
+    } else {
+      // Otherwise, populate the deltas. The fact that this is sorted (and this has a final finish time) ensures
+      // that 0 and i - 1 will both have final finish times
+      entriesWithDelta.push({
+        ...entriesSorted[i],
+        deltaToNext:
+          entriesSorted[i].finalFinishTime! -
+          entriesSorted[i - 1].finalFinishTime!,
+        deltaToWinner:
+          entriesSorted[i].finalFinishTime! - entriesSorted[0].finalFinishTime!,
+      });
+    }
+  }
+
+  // Return the final, processed list
   return {
     ...heat,
     scheduledStart: new Date(heat.scheduledStart),
+    entries: entriesWithDelta,
   };
 }
 

--- a/packages/site/src/lib/utils/regattas/converters.ts
+++ b/packages/site/src/lib/utils/regattas/converters.ts
@@ -1,0 +1,59 @@
+import { RegattaService } from "@qra-website/core";
+import { CollectionItem, EntityItem } from "electrodb";
+
+/**
+ * Converts a heat (as it would be returned from the DB) to one that can be used
+ * in the frontend (e.g., with more useful types)
+ * @param heat the heat to convert
+ * @returns the converted heat, with more useful typings
+ */
+export function convertDbHeatToHeat(
+  heat: EntityItem<typeof RegattaService.entities.heat>,
+) {
+  return {
+    ...heat,
+    scheduledStart: new Date(heat.scheduledStart),
+  };
+}
+
+/**
+ * Converts a regatta (as it would be returned from the DB) to one containing
+ * more useful typings for easier use in the frontend
+ * @param regattaSummary the regatta as returned from the DB
+ * @returns a regatta created with more useful typings
+ */
+export function convertDbRegattaSummaryToRegattaSummary(
+  regattaSummary: EntityItem<typeof RegattaService.entities.regatta>,
+) {
+  return {
+    ...regattaSummary,
+    startDate: new Date(regattaSummary.startDate),
+    endDate: new Date(regattaSummary.endDate),
+  };
+}
+
+/**
+ * Method to convert the DB returned regatta details to one with more useful types
+ * @param regattaDetails the DB returned regatta details to display
+ * @returns regatta details with more useful types, or null if the returned data has no regatta
+ * @throws {Error} if the passed-in regatta details contain more than one regatta
+ */
+export function convertDbRegattaDetailsToRegattaDetails(
+  regattaDetails: CollectionItem<typeof RegattaService, "regatta">,
+) {
+  // If we got no regatta
+  if (regattaDetails.regatta.length === 0) {
+    return null; // Return null
+  } else if (regattaDetails.regatta.length !== 1) {
+    // If we somehow got more than one regatta, throw
+    throw new Error(
+      `Invalid input - regatta details must have exactly one regatta (found ${regattaDetails.regatta.length})`,
+    );
+  }
+
+  // Otherwise, return, call the converters for the subtypes
+  return {
+    regatta: convertDbRegattaSummaryToRegattaSummary(regattaDetails.regatta[0]),
+    heat: regattaDetails.heat.map(convertDbHeatToHeat),
+  };
+}

--- a/packages/site/src/lib/utils/regattas/converters.ts
+++ b/packages/site/src/lib/utils/regattas/converters.ts
@@ -54,23 +54,23 @@ export function convertDbHeatToHeat(
   // Then, fall back to bow number order
   const entriesSorted = entriesNoDelta.toSorted((a, b) => {
     if (a.finalFinishTime && b.finalFinishTime) {
-      return b.finalFinishTime - a.finalFinishTime; // Reverse cuz lower is higher in this case
+      return a.finalFinishTime - b.finalFinishTime;
     } else if (a.finalFinishTime) {
-      return 1;
+      return -1; // A is less than (closer to start/top)
     } else if (b.finalFinishTime) {
-      return -1;
+      return 1;
     } else if (a.didFailToFinish && b.didFailToFinish) {
       return a.bowNumber - b.bowNumber;
     } else if (a.didFailToFinish) {
-      return 1;
+      return -1;
     } else if (b.didFailToFinish) {
-      return -1;
-    } else if (a.penalty && b.penalty && a.rawFinishTime && b.rawFinishTime) {
-      return b.rawFinishTime - a.rawFinishTime; // Again, reverse cuz lower is higher
-    } else if (a.penalty) {
       return 1;
-    } else if (b.penalty) {
+    } else if (a.penalty && b.penalty && a.rawFinishTime && b.rawFinishTime) {
+      return a.rawFinishTime - b.rawFinishTime;
+    } else if (a.penalty) {
       return -1;
+    } else if (b.penalty) {
+      return 1;
     } else {
       return a.bowNumber - b.bowNumber;
     }

--- a/packages/site/src/lib/utils/regattas/converters.ts
+++ b/packages/site/src/lib/utils/regattas/converters.ts
@@ -2,6 +2,20 @@ import { RegattaService } from "@qra-website/core";
 import { CollectionItem, EntityItem } from "electrodb";
 
 /**
+ * Method that converts a break as retrieved from the database to a break with more useful typing information
+ * @param dbBreak the break that has been retrieved from the database
+ * @returns the processed break with better type information
+ */
+export function convertDbBreakToBreak(
+  dbBreak: EntityItem<typeof RegattaService.entities.break>,
+) {
+  return {
+    ...dbBreak,
+    scheduledStart: new Date(dbBreak.scheduledStart),
+  };
+}
+
+/**
  * Converts a heat (as it would be returned from the DB) to one that can be used
  * in the frontend (e.g., with more useful types)
  * @param heat the heat to convert
@@ -165,5 +179,6 @@ export function convertDbRegattaDetailsToRegattaDetails(
   return {
     regatta: convertDbRegattaSummaryToRegattaSummary(regattaDetails.regatta[0]),
     heat: regattaDetails.heat.map(convertDbHeatToHeat),
+    break: regattaDetails.break.map(convertDbBreakToBreak),
   };
 }

--- a/packages/site/src/lib/utils/regattas/get-heats-by-date.ts
+++ b/packages/site/src/lib/utils/regattas/get-heats-by-date.ts
@@ -1,6 +1,7 @@
 import { RegattaService } from "@qra-website/core";
 import { cache } from "react";
 import "server-only"; // This ensures this library will never under any circumstances be included in the client bundle
+import { convertDbHeatToHeat } from "./converters";
 
 /**
  * Method to preload the date values. This can be called before the data is
@@ -32,12 +33,7 @@ export const getHeatsByDate = cache(
           },
         )
         .go()
-    ).data // Coerce dates to date objects
-      .map((heat) => {
-        return {
-          ...heat,
-          scheduledStart: new Date(heat.scheduledStart),
-        };
-      });
+    ).data // Coerce the heat objects
+      .map(convertDbHeatToHeat);
   },
 );

--- a/packages/site/src/lib/utils/regattas/get-regatta-details.ts
+++ b/packages/site/src/lib/utils/regattas/get-regatta-details.ts
@@ -1,5 +1,6 @@
 import { RegattaService } from "@qra-website/core";
 import { cache } from "react";
+import { convertDbRegattaDetailsToRegattaDetails } from "./converters";
 
 /**
  * Method to asynchronously preload and cache details about the requested regatta, so that when it is retrieved, its details are cached
@@ -12,31 +13,17 @@ export const preload = (regattaId: string) => {
 /**
  * Method to fetch the details about a given regatta, including all of its heat information, by its ID
  * @param regattaId the ID of the regatta to query details and heats for
- * @returns all information about the requested regatta
+ * @returns all information about the requested regatta, or null if the ID is invalid
  */
 export const getRegattaDetails = cache(async (regattaId: string) => {
-  const data = (
-    await RegattaService.collections
-      .regatta({
-        regattaId: regattaId,
-      })
-      .go()
-  ).data;
-
-  // Coerce dates to date objects and return
-  return {
-    regatta: data.regatta.map((regatta) => {
-      return {
-        ...regatta,
-        startDate: new Date(regatta.startDate),
-        endDate: new Date(regatta.endDate),
-      };
-    }),
-    heat: data.heat.map((heat) => {
-      return {
-        ...heat,
-        scheduledStart: new Date(heat.scheduledStart),
-      };
-    }),
-  };
+  // Call the converter
+  return convertDbRegattaDetailsToRegattaDetails(
+    (
+      await RegattaService.collections
+        .regatta({
+          regattaId: regattaId,
+        })
+        .go()
+    ).data,
+  );
 });

--- a/packages/site/src/lib/utils/regattas/get-regattas-summary.ts
+++ b/packages/site/src/lib/utils/regattas/get-regattas-summary.ts
@@ -1,6 +1,7 @@
 import { RegattaService } from "@qra-website/core";
 import { cache } from "react";
 import "server-only"; // This ensures this library will never under any circumstances be included in the client bundle
+import { convertDbRegattaSummaryToRegattaSummary } from "./converters";
 
 /**
  * Method to preload the date values. This can be called before
@@ -54,12 +55,6 @@ export const getRegattasSummary = cache(
         )
         .go()
     ).data // Coerce dates to date objects
-      .map((regatta) => {
-        return {
-          ...regatta,
-          startDate: new Date(regatta.startDate),
-          endDate: new Date(regatta.endDate),
-        };
-      });
+      .map(convertDbRegattaSummaryToRegattaSummary);
   },
 );


### PR DESCRIPTION
Updates various regatta DB configuration items/items to include:
* Finish delta calculations in the frontend utils packages
* Penalty/DNF information in the database
* Requiring heats to have a display name in the database
* Adding break information to the database

This resolves #17
This resolves #21 
This resolves #20 
This resolves #16 